### PR TITLE
Add proposal validation strategies

### DIFF
--- a/proposal-validation/klima.json
+++ b/proposal-validation/klima.json
@@ -1,0 +1,59 @@
+[
+  {
+    "name": "KLIMA token holder",
+    "strategy": {
+      "name": "math",
+      "params": {
+        "symbol": "wsKLIMA",
+        "operands": [
+          {
+            "type": "strategy",
+            "strategy": {
+              "network": "137",
+              "name": "erc20-balance-of",
+              "params": {
+                "address": "0x4e78011ce80ee02d2c3e649fb657e45898257815",
+                "symbol": "KLIMA",
+                "decimals": 9
+              }
+            }
+          },
+          {
+            "type": "strategy",
+            "strategy": {
+              "name": "contract-call",
+              "network": "137",
+              "params": {
+                "address": "0x25d28a24Ceb6F81015bB0b2007D795ACAc411b4d",
+                "decimals": 9,
+                "symbol": "index",
+                "args": [],
+                "methodABI": {
+                  "inputs": [],
+                  "name": "index",
+                  "outputs": [
+                    {
+                      "internalType": "uint256",
+                      "name": "",
+                      "type": "uint256"
+                    }
+                  ],
+                  "payable": false,
+                  "stateMutability": "view",
+                  "type": "function"
+                }
+              }
+            }
+          }
+        ],
+        "operation": "divide"
+      }
+    },
+    "network": "137",
+    "addresses": [
+        "0x4e78011ce80ee02d2c3e649fb657e45898257815",
+        "0xaDe95E98fa18c40345EecD2688188d9b9cb40313"
+    ],
+    "snapshot": 28089882
+  }
+]

--- a/proposal-validation/sklima.json
+++ b/proposal-validation/sklima.json
@@ -1,0 +1,59 @@
+[
+  {
+    "name": "sKLIMA token holder",
+    "strategy": {
+      "name": "math",
+      "params": {
+        "symbol": "wsKLIMA",
+        "operands": [
+          {
+            "type": "strategy",
+            "strategy": {
+              "network": "137",
+              "name": "erc20-balance-of",
+              "params": {
+                "address": "0xb0C22d8D350C67420f06F48936654f567C73E8C8",
+                "symbol": "sKLIMA",
+                "decimals": 9
+              }
+            }
+          },
+          {
+            "type": "strategy",
+            "strategy": {
+              "name": "contract-call",
+              "network": "137",
+              "params": {
+                "address": "0x25d28a24Ceb6F81015bB0b2007D795ACAc411b4d",
+                "decimals": 9,
+                "symbol": "index",
+                "args": [],
+                "methodABI": {
+                  "inputs": [],
+                  "name": "index",
+                  "outputs": [
+                    {
+                      "internalType": "uint256",
+                      "name": "",
+                      "type": "uint256"
+                    }
+                  ],
+                  "payable": false,
+                  "stateMutability": "view",
+                  "type": "function"
+                }
+              }
+            }
+          }
+        ],
+        "operation": "divide"
+      }
+    },
+    "network": "137",
+    "addresses": [
+        "0x6f370dba99E32A3cAD959b341120DB3C9E280bA6",
+        "0xbDBd4347b082D9d6BdF2Da4555a37Ce52a2e2120"
+    ],
+    "snapshot": 28091084
+  }
+]

--- a/proposal-validation/wsklima.json
+++ b/proposal-validation/wsklima.json
@@ -1,0 +1,17 @@
+{
+  "name": "wsKLIMA token holder",
+  "strategy": {
+    "name": "erc20-balance-of",
+    "params": {
+      "address": "0x6f370dba99E32A3cAD959b341120DB3C9E280bA6",
+      "symbol": "wsKLIMA",
+      "decimals": 18
+    }
+  },
+  "network": "137",
+  "addresses": [
+    "0xd4e692eb01861f2bc0534b9a1afd840719648c49",
+    "0x414B4b5a2A0e303B89360EdA83598aB7702EAe04"
+  ],
+  "snapshot": 28091249
+}


### PR DESCRIPTION
Add reference implementations with parameters for wsKLIMA proposal validation logic

Note: the >1000 wsKLIMA cutoff must be set in the Snapshot proposal validation configuration page manually as documented here: https://docs.snapshot.org/user-guides/strategies/validation-strategies#validation-strategy-example-basic

After setting the limit, select custom strategies and then configure each of the 3 sets of parameters in this PR

NOTE: excluded wsKLIMA sourced from C3 staked wsKLIMA, as well as from CO2Compound, since the amounts there are too small to matter

Could add in the C3 staked wsKLIMA for good measure...